### PR TITLE
Run Laravel initialization commands on container startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+
+services:
+  app:
+    image: webdevops/php-nginx:7.4
+    container_name: laravel-app
+    working_dir: /app
+    environment:
+      WEB_DOCUMENT_ROOT: /app/public
+      DB_HOST: mysql
+      DB_DATABASE: laravel
+      DB_USERNAME: laravel
+      DB_PASSWORD: secret
+      FORGE_COMPOSER: composer
+      FORGE_PHP: php
+      FORGE_PHP_FPM: php-fpm
+    volumes:
+      - ./:/app
+    ports:
+      - "8000:80"
+    command: ["/app/docker/startup.sh"]
+    depends_on:
+      - mysql
+      - redis
+
+  mysql:
+    image: mysql:5.7
+    container_name: laravel-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: laravel
+      MYSQL_USER: laravel
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - mysql_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
+  redis:
+    image: redis:5-alpine
+    container_name: laravel-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+volumes:
+  mysql_data:

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+: "${FORGE_COMPOSER:=composer}"
+: "${FORGE_PHP:=php}"
+: "${FORGE_PHP_FPM:=php-fpm}"
+
+# Install PHP dependencies optimized for production.
+$FORGE_COMPOSER install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+
+# Prevent concurrent php-fpm reloads.
+touch /tmp/fpmlock 2>/dev/null || true
+if command -v flock >/dev/null 2>&1; then
+  (
+    flock -w 10 9 || exit 1
+    echo 'Reloading PHP FPM...'
+    if command -v service >/dev/null 2>&1; then
+      service "$FORGE_PHP_FPM" reload || true
+    fi
+  ) 9</tmp/fpmlock
+fi
+
+# Run database migrations if the artisan binary is present.
+if [ -f artisan ]; then
+  $FORGE_PHP artisan migrate --force
+fi
+
+# Start the default process from the base image once initialization is complete.
+if [ -x /opt/docker/bin/entrypoint ]; then
+  exec /opt/docker/bin/entrypoint supervisord
+fi
+
+exec supervisord


### PR DESCRIPTION
## Summary
- add a startup script that installs dependencies, reloads php-fpm, and runs database migrations when the container launches
- configure the docker-compose app service to expose Forge command environment variables and execute the startup script on boot

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f40ddf948330abd19fa538962a5b)