### PR TITLE
Automate Laravel setup during Docker startup

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -5,8 +5,40 @@ set -e
 : "${FORGE_PHP:=php}"
 : "${FORGE_PHP_FPM:=php-fpm}"
 
-# Install PHP dependencies optimized for production.
-$FORGE_COMPOSER install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+# Install PHP dependencies.
+$FORGE_COMPOSER install --no-interaction --no-scripts --prefer-dist
+
+# Ensure the application environment file exists and is configured.
+if [ ! -f .env ] && [ -f .env.example ]; then
+  cp .env.example .env
+fi
+
+set_env() {
+  key="$1"
+  value="$2"
+
+  if [ -z "$key" ] || [ -z "$value" ]; then
+    return
+  fi
+
+  if grep -q "^${key}=" .env 2>/dev/null; then
+    sed -i "s#^${key}=.*#${key}=${value}#" .env
+  else
+    printf '%s=%s\n' "$key" "$value" >> .env
+  fi
+}
+
+set_env "DB_CONNECTION" "${DB_CONNECTION:-mysql}"
+set_env "DB_HOST" "${DB_HOST:-127.0.0.1}"
+set_env "DB_PORT" "${DB_PORT:-3306}"
+set_env "DB_DATABASE" "${DB_DATABASE:-homestead}"
+set_env "DB_USERNAME" "${DB_USERNAME:-homestead}"
+set_env "DB_PASSWORD" "${DB_PASSWORD:-secret}"
+
+# Generate the application key.
+if [ -f artisan ]; then
+  $FORGE_PHP artisan key:generate --force
+fi
 
 # Prevent concurrent php-fpm reloads.
 touch /tmp/fpmlock 2>/dev/null || true
@@ -22,7 +54,7 @@ fi
 
 # Run database migrations if the artisan binary is present.
 if [ -f artisan ]; then
-  $FORGE_PHP artisan migrate --force
+  $FORGE_PHP artisan migrate --force --seed
 fi
 
 # Start the default process from the base image once initialization is complete.

--- a/readme.md
+++ b/readme.md
@@ -1,47 +1,69 @@
-<p align="center"><img src="https://laravel.com/assets/img/components/logo-laravel.svg"></p>
+<p align="center"><img src="https://laravel.com/assets/img/components/logo-laravel.svg" alt="Laravel"></p>
 
-#  Sistema de Saldo com Laravel
+# Sistema de Saldo com Laravel
 
-Algumas pastas estão ignoradas pelo .gitignore.
+Algumas pastas estão ignoradas pelo `.gitignore`.
 
-Levando em consideração que você tenha o <code> php </code> e <code> composer </code> na sua variável global PATH, para uma nova instalação do Laravel.
+Certifique-se de ter `php` e `composer` configurados na sua variável global `PATH` para realizar uma nova instalação do Laravel.
 
+## Clonando o projeto
 
-# Clonando o projeto 
+Considere que você esteja em um sistema operacional Linux ou Windows com o Git instalado e execute os passos a seguir:
 
-Vou  considerar que você esteja rodando um sistema operacional Linux/Windows e com o git instalado, faça o seguinte:
+1. **Clone o projeto**
 
-<strong> Clone o projeto</strong> <br>
-<code>  git clone  https://github.com/Dhayllin/laravel_saldo.git  </code> 
-<br>
+   ```bash
+   git clone https://github.com/Dhayllin/laravel_saldo.git
+   ```
 
-<strong> Instale as dependências e o framework</strong>
-<br>
-<code>
-composer install --no-scripts
-</code>
+2. **Instale as dependências e o framework**
 
-<strong>Copie o arquivo .env.example</strong>
-<br>
-<code> cp .env.example .env </code>
+   ```bash
+   composer install --no-scripts
+   ```
 
-<strong> Crie uma nova chave para a aplicação</strong>
-<br>
-<code>php artisan key:generate</code>
+3. **Copie o arquivo `.env.example`**
 
-Alterar as configurações do seu .env para
+   ```bash
+   cp .env.example .env
+   ```
 
+4. **Crie uma nova chave para a aplicação**
+
+   ```bash
+   php artisan key:generate
+   ```
+
+5. **Atualize o arquivo `.env`** com as configurações abaixo:
+
+   ```env
+   DB_CONNECTION=mysql
+   DB_HOST=127.0.0.1
+   DB_PORT=3306
+   DB_DATABASE=homestead
+   DB_USERNAME=homestead
+   DB_PASSWORD=secret
+   ```
+
+6. **Execute as migrations e os seeders**
+
+   ```bash
+   php artisan migrate --seed
+   ```
+
+## Executando com Docker
+
+O projeto fornece um ambiente Docker que automatiza toda a preparação descrita acima. Ao executar o comando abaixo, o container da aplicação irá:
+
+- instalar as dependências com `composer install --no-scripts`;
+- garantir que o arquivo `.env` exista e esteja configurado com as variáveis de banco de dados listadas anteriormente;
+- gerar a chave da aplicação;
+- executar `php artisan migrate --seed` automaticamente.
+
+Para iniciar o ambiente, utilize:
+
+```bash
+docker-compose up --build
 ```
 
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
-
-```
-
-E rodar as migrations com:
-
-<code> php artisan migrate --seed </code>
+Após o container subir, a aplicação estará disponível em `http://localhost:8000`.


### PR DESCRIPTION
## Summary
- ensure the Docker startup script installs dependencies, prepares .env and runs migrations with seeders
- document the automated setup steps when running docker-compose up

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691624c58c3883309b06b05949d6facd)