### PR TITLE
Handle Firebase database 404 errors as HTTP not found responses

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,9 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Kreait\Firebase\Exception\Database\DatabaseError;
+use Kreait\Firebase\Exception\Database\ReferenceNotFound;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -46,6 +49,14 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        if ($exception instanceof ReferenceNotFound) {
+            throw new NotFoundHttpException('The requested Firebase resource could not be found.', $exception);
+        }
+
+        if ($exception instanceof DatabaseError && $exception->getMessage() === '404 Not Found') {
+            throw new NotFoundHttpException('The requested Firebase resource could not be found.', $exception);
+        }
+
         return parent::render($request, $exception);
     }
 }


### PR DESCRIPTION
## Summary
- convert Firebase ReferenceNotFound exceptions into HTTP 404 responses
- treat Firebase database errors with a 404 message as not found responses to improve feedback

## Testing
- not run (composer dependencies unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178b1bd09c8330b43d150df1d1fbe5)