### PR TITLE
Set storage ownership in startup script

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -8,6 +8,9 @@ set -e
 # Install PHP dependencies matching the container runtime.
 $FORGE_COMPOSER install --no-interaction --no-scripts --prefer-dist
 
+# Ensure writable permissions on required directories by setting ownership.
+chown -R "$(id -u)":"$(id -g)" storage bootstrap/cache 2>/dev/null || true
+
 # Ensure the application environment file exists and is configured.
 if [ ! -f .env ] && [ -f .env.example ]; then
   cp .env.example .env


### PR DESCRIPTION
## Summary
- replace the broad chmod command with a chown to the current user for storage and bootstrap/cache directories during startup initialization

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916378ac8908330889b47d98707be0f)